### PR TITLE
ContinueToolbar width full → fit

### DIFF
--- a/src/pages/read/[translation].astro
+++ b/src/pages/read/[translation].astro
@@ -32,7 +32,7 @@ const MDs = await getCollection("translations", ({ data }) => {
   <Nav href="/" label="Home" />
   <div
     id="continueToolbar"
-    class="hidden absolute transition-opacity opacity-0 w-full gap-4 justify-between md:justify-start lg:flex-col lg:gap-2 px-8 md:px-12 py-6 mx-auto"
+    class="hidden absolute transition-opacity opacity-0 w-fit gap-4 justify-between md:justify-start lg:flex-col lg:gap-2 px-8 md:px-12 py-6 mx-auto"
   >
     <a
       class="w-max text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200 focus:text-zinc-900 dark:focus:text-zinc-200 transition-all duration-200 underline-offset-2 outline-none focus-visible:ring-2 ring-zinc-500 ring-offset-zinc-100 dark:ring-offset-zinc-900 ring-offset-2 underline group"


### PR DESCRIPTION
Toolbar was rendering over the chapter making some text hard to select.

Before:
![image](https://user-images.githubusercontent.com/37847523/217349236-3bddec33-cfec-4c96-85ad-489637fc2a4a.png)


After: 
![image](https://user-images.githubusercontent.com/37847523/217349004-ac5e4ac4-2ec0-452a-a8a3-bb1b982d05a7.png)
